### PR TITLE
add anomaly_reason parameter to types_fmt.py

### DIFF
--- a/mapilio_kit/components/types_fmt.py
+++ b/mapilio_kit/components/types_fmt.py
@@ -121,6 +121,7 @@ FinalImageDescriptionMetadata = {
         "imageSize": {"type": "string"},
         "fov": {"type": "number"},
         "anomaly": {"type": "number"},
+        "anomaly_reason": {"type": "string"},
         "yaw": {"type": "number"},
         "carSpeed": {"type": "number"},
         "pitch": {"type": "number"},


### PR DESCRIPTION
There was a problem on upload process. After debugging it I found the source. It was related to anomaly reason parameter. According to the new updates kit provides anomaly reason, however, on validate schema it wasn't exist that's why we weren't be able to upload the data. It fixed now. 