### PR TITLE
add anomaly reason parameter to schema

### DIFF
--- a/mapilio_kit/components/utilities/types_fmt.py
+++ b/mapilio_kit/components/utilities/types_fmt.py
@@ -156,6 +156,7 @@ FinalImageDescriptionMetadata = {
         "imageSize": {"type": "string"},
         "fov": {"type": "number"},
         "anomaly": {"type": "number"},
+        "anomaly_reason" : {"type": "string"},
         "yaw": {"type": "number"},
         "carSpeed": {"type": "number"},
         "pitch": {"type": "number"},


### PR DESCRIPTION
Due to the problem occurred during schema validation on upload process, anomaly_reason parameter were added. 