### PR TITLE
Fix ExifTool XML namespaces

### DIFF
--- a/mapilio_kit/components/geotagging/gps_from_gopro360.py
+++ b/mapilio_kit/components/geotagging/gps_from_gopro360.py
@@ -103,11 +103,13 @@ def move_all_files(ifolder, ofolder, file_filter):
 
 def get_gps_date_time(xml_metadata_file):
     xroot = XET.parse(xml_metadata_file).getroot()
-    gps_date_time = ""
     for x in xroot.iter('{http://ns.exiftool.ca/QuickTime/Track4/1.0/}GPSDateTime'):
-        gps_date_time = x.text
-        break
-    return gps_date_time
+        return x.text
+
+    for x in xroot.iter('{http://ns.exiftool.org/QuickTime/Track4/1.0/}GPSDateTime'):
+        return x.text
+        
+    return ""
 
 
 def get_gpx_fmt_url():

--- a/mapilio_kit/components/processing/processing.py
+++ b/mapilio_kit/components/processing/processing.py
@@ -264,7 +264,7 @@ def overwrite_exif_tags(
     if overwrite_all_EXIF_tags or overwrite_EXIF_direction_tag:
         heading = desc.get("heading")
         if heading is not None:
-            image_exif.set_direction(heading["heading"])
+            image_exif.set_direction(desc["heading"])
             modified = True
 
     if overwrite_all_EXIF_tags or overwrite_EXIF_orientation_tag:


### PR DESCRIPTION
In recent versions of Exiftool, the XML namespace moved to `ns.exiftool.org` instead of `ns.exiftool.ca` ([see code occurences](https://github.com/search?q=repo%3Aexiftool%2Fexiftool%20ns.exiftool.org&type=code)), this breaks the GoPro 360 video files processing. This PR offers a fix where both names are used to locate timestamp in XML file, so it doesn't matter what exiftool version is available on the system.